### PR TITLE
Conj dirichlet

### DIFF
--- a/R/conjugate.R
+++ b/R/conjugate.R
@@ -358,10 +358,10 @@ conjugate<-function(s1 = NULL, s2= NULL, method = c("t", "gaussian", "beta", "lo
   }
 
   #* `Make plot`
-  if(matched_arg != "dirichlet" & plot){
-    res <- .conj_general_plot(res, s2, rope_range, support, rope_ci)
-  } else if (matched_arg == "dirichlet" & plot){
+  if(grepl("dirichlet", matched_arg) & plot){
     res <- .conj_diri_plot(res, s2, rope_range, rope_ci)
+  } else {
+    res <- .conj_general_plot(res, s2, rope_range, support, rope_ci)
   }
   
   return(res)
@@ -2437,8 +2437,8 @@ conjugate<-function(s1 = NULL, s2= NULL, method = c("t", "gaussian", "beta", "lo
       mode = '1'
     }
     
-    rope_plot <- ggplot2::ggplot(rdf, ggplot2::aes(xmin=bin-rect_width, xmax = bin+rect_width,
-                                              ymin=CI_low, ymax=CI_high ))+
+    rope_plot <- ggplot2::ggplot(rdf, ggplot2::aes(xmin=.data$bin-rect_width, xmax = .data$bin+rect_width,
+                                              ymin=.data$CI_low, ymax=.data$CI_high ))+
       lapply(1:length(cis), function(i){
         ggplot2::geom_rect(data = rdf[rdf$CI == cis[[i]], ], ggplot2::aes(fill = as.character(cis[[i]]) ))
       })+

--- a/R/conjugate.R
+++ b/R/conjugate.R
@@ -1984,7 +1984,23 @@ conjugate<-function(s1 = NULL, s2= NULL, method = c("t", "gaussian", "beta", "lo
 #' @param s2 An optional second sample of the same form as s2.
 #' @examples
 #' 
-#' 1+1
+#' makeMvLn<-function(bins=500,mu_log,sigma_log){
+#' setNames(data.frame(matrix(hist(rlnorm(2000,mu_log, sigma_log),
+#'                                 breaks=seq(1,bins,5), plot=FALSE)$counts, nrow=1)),
+#'                                          paste0("b",seq(1,bins,5))[-1] ) }
+#' set.seed(123) 
+#' mv_ln<-rbind(do.call(rbind,
+#'                       lapply(1:30, function(i){makeMvLn(mu_log=log(130),
+#'                                           sigma_log=log(1.3) )})),
+#'             do.call(rbind, lapply(1:30, function(i){makeMvLn(mu_log=log(100),
+#'                                           sigma_log=log(1.2) )})))
+#' mv_ln$group = rep(c("a", "b"), each = 30)
+#' s1 <- mv_ln[mv_ln$group=="a", 1:99]
+#' s2 <- mv_ln[mv_ln$group=="b", 1:99]                            
+#' out <- .conj_diri_mv_1(s1, s2, priors=NULL, plot=TRUE, rope_range = c(-0.1, 0.1),
+#'       rope_ci = 0.89, rope_hdi = 0.95, cred.int.level = 0.89, hypothesis="equal")
+#' dim(out$summary) # summary is still one row dataframe
+#' dim(out$summary$HDI_rope[[1]]) # with nested dataframes.
 #' 
 #' @keywords internal
 #' @noRd
@@ -2131,12 +2147,12 @@ conjugate<-function(s1 = NULL, s2= NULL, method = c("t", "gaussian", "beta", "lo
       
       out$dirSymbol <- dirSymbol
       out$summary = cbind(out$summary, data.frame('HDE_rope' = list(NA), 'HDI_rope' = list(NA),
-                                                  "mean_rope_prob" = mean_rope_prob))
+                                                  "rope_probs" = list(NA), "mean_rope_prob" = mean_rope_prob))
       out$summary <- data.table::as.data.table(out$summary)
       out$summary$HDE_rope <- list(HDE_rope)
       out$summary$HDI_rope <- list(HDI_rope)
+      out$summary$rope_probs <- list(rope_probs)
       out$summary <- as.data.frame(out$summary)
-      out$rope_probs <- rope_probs
     } else{
       stop("rope must be a vector of length 2")
     }

--- a/R/conjugate.R
+++ b/R/conjugate.R
@@ -216,7 +216,7 @@
 #'       rope_range = c(-0.025, 0.025), rope_ci = 0.89, 
 #'       cred.int.level = 0.89, hypothesis="equal")
 #'       
-#' diri_ex_1 <- conjugate(s1, s2, method = "dirichlet2", priors=NULL, plot=TRUE,
+#' diri_ex_2 <- conjugate(s1, s2, method = "dirichlet2", priors=NULL, plot=TRUE,
 #'       rope_range = c(-0.025, 0.025), rope_ci = 0.89, 
 #'       cred.int.level = 0.89, hypothesis="equal")  
 #'       
@@ -2432,9 +2432,10 @@ conjugate<-function(s1 = NULL, s2= NULL, method = c("t", "gaussian", "beta", "lo
     rdf <- res$rope_df
     cis<-rev(unique(rdf$CI))
     virPal <- viridis::plasma(length(cis), direction=-1)
+    mode = "2"
     if(length(virPal)==1){
       virPal = "gray40"
-      mode = '1'
+      mode = "1"
     }
     
     rope_plot <- ggplot2::ggplot(rdf, ggplot2::aes(xmin=.data$bin-rect_width, xmax = .data$bin+rect_width,

--- a/man/conjugate.Rd
+++ b/man/conjugate.Rd
@@ -7,7 +7,8 @@
 conjugate(
   s1 = NULL,
   s2 = NULL,
-  method = c("t", "gaussian", "beta", "lognormal", "poisson", "negbin", "dirichlet"),
+  method = c("t", "gaussian", "beta", "lognormal", "poisson", "negbin", "dirichlet",
+    "dirichlet2"),
   priors = NULL,
   plot = FALSE,
   rope_range = NULL,
@@ -24,13 +25,18 @@ If a multi value trait is used then column names should include a number represe
 \item{s2}{An optional second sample of the same form as s2.}
 
 \item{method}{The distribution/method to use.
-Currently "t", "gaussian", "beta", "lognormal", "poisson", "negbin" (negative binomial), and "dirichlet"
+Currently "t", "gaussian", "beta", "lognormal", "poisson", "negbin" (negative binomial), "dirichlet", and "dirichlet2"
 are supported. The count distributions (poisson and negative binomial) 
-are only implemented for single value traits. Dirichlet is only implemented with multi value traits and
+are only implemented for single value traits. Dirichlets are only implemented with multi value traits and
 will return the summary component as a data.table with nested data frames for the ROPE HDI/HDE
 if rope_range is specified. For brevity the HDE and HDI of the samples are not returned when
-using the dirichlet method.
-Note that "t" and "gaussian" both use a T distribution with "t" testing for a difference
+using the dirichlet method. The "dirichlet" method does not compute an HDI and only compares how much of the posterior
+distribution (sample 1 - sample 2) is within the ROPE interval. The "dirichlet2" method does make an HDI and run normal 
+ROPE tests per each bin using the alpha vector from each sample to simulate draws from the dirichlet. Bear in mind
+ that dirichlet is sensitive to the total number of counts in the data. If the mean vector
+(alpha_vec ~ mean_vec * precision) were to be used instead of the alpha vector then the distributions
+in each bin would be much wider.
+The "t" and "gaussian" methods both use a T distribution with "t" testing for a difference
  of means and "gaussian" testing for a difference in the distributions (similar to a Z test).}
 
 \item{priors}{Prior distributions described as a list. This varies by method, see details.
@@ -243,7 +249,9 @@ diri_ex_1 <- conjugate(s1, s2, method = "dirichlet", priors=NULL, plot=TRUE,
       rope_range = c(-0.025, 0.025), rope_ci = 0.89, 
       cred.int.level = 0.89, hypothesis="equal")
       
-      
+diri_ex_1 <- conjugate(s1, s2, method = "dirichlet2", priors=NULL, plot=TRUE,
+      rope_range = c(-0.025, 0.025), rope_ci = 0.89, 
+      cred.int.level = 0.89, hypothesis="equal")  
       
 
 

--- a/man/conjugate.Rd
+++ b/man/conjugate.Rd
@@ -249,7 +249,7 @@ diri_ex_1 <- conjugate(s1, s2, method = "dirichlet", priors=NULL, plot=TRUE,
       rope_range = c(-0.025, 0.025), rope_ci = 0.89, 
       cred.int.level = 0.89, hypothesis="equal")
       
-diri_ex_1 <- conjugate(s1, s2, method = "dirichlet2", priors=NULL, plot=TRUE,
+diri_ex_2 <- conjugate(s1, s2, method = "dirichlet2", priors=NULL, plot=TRUE,
       rope_range = c(-0.025, 0.025), rope_ci = 0.89, 
       cred.int.level = 0.89, hypothesis="equal")  
       

--- a/man/conjugate.Rd
+++ b/man/conjugate.Rd
@@ -7,12 +7,11 @@
 conjugate(
   s1 = NULL,
   s2 = NULL,
-  method = c("t", "gaussian", "beta", "lognormal", "poisson", "negbin"),
+  method = c("t", "gaussian", "beta", "lognormal", "poisson", "negbin", "dirichlet"),
   priors = NULL,
   plot = FALSE,
   rope_range = NULL,
   rope_ci = 0.89,
-  rope_hdi = 0.95,
   cred.int.level = 0.89,
   hypothesis = "equal",
   support = NULL
@@ -25,9 +24,12 @@ If a multi value trait is used then column names should include a number represe
 \item{s2}{An optional second sample of the same form as s2.}
 
 \item{method}{The distribution/method to use.
-Currently "t", "gaussian", "beta", "lognormal", "poisson", and "negbin" (negative binomial)
- are supported. The count distributions (poisson and negative binomial) 
- are only implemented for single value traits.
+Currently "t", "gaussian", "beta", "lognormal", "poisson", "negbin" (negative binomial), and "dirichlet"
+are supported. The count distributions (poisson and negative binomial) 
+are only implemented for single value traits. Dirichlet is only implemented with multi value traits and
+will return the summary component as a data.table with nested data frames for the ROPE HDI/HDE
+if rope_range is specified. For brevity the HDE and HDI of the samples are not returned when
+using the dirichlet method.
 Note that "t" and "gaussian" both use a T distribution with "t" testing for a difference
  of means and "gaussian" testing for a difference in the distributions (similar to a Z test).}
 
@@ -49,9 +51,6 @@ decision-making \url{https://doi.org/10.3758/s13423-016-1221-4}
 and \url{https://doi.org/10.1177/251524591877130}.}
 
 \item{rope_ci}{The credible interval probability to use for ROPE. Defaults to 0.89.}
-
-\item{rope_hdi}{The credible interval probability to use in computing the highest
-density interval (HDI) of the posterior distribution for ROPE. This defaults to 0.95.}
 
 \item{cred.int.level}{The credible interval probability to use 
 in computing HDI for samples, defaults to 0.89.}
@@ -108,7 +107,7 @@ makeMvLn<-function(bins=500,mu_log,sigma_log){
    setNames(data.frame(matrix(hist(rlnorm(2000,mu_log, sigma_log),
       breaks=seq(1,bins,5), plot=FALSE)$counts, nrow=1)),
     paste0("b",seq(1,bins,5))[-1] ) }
-   set.seed(123) 
+set.seed(123) 
 mv_ln<-rbind(do.call(rbind,
            lapply(1:30, function(i){makeMvLn(mu_log=log(130),
              sigma_log=log(1.3) )})),
@@ -119,14 +118,14 @@ mv_ln<-rbind(do.call(rbind,
 # lognormal mv
 ln_mv_ex <- conjugate(s1 = mv_ln[1:30,], s2= mv_ln[31:60,], method = "lognormal",
                    priors = list( mu_log=c(log(10),log(10)),n=c(1,1),sigma_log=c(log(3),log(3)) ),
-                   plot=TRUE, rope_range = c(-40,40), rope_ci = 0.89, rope_hdi = 0.95,
+                   plot=TRUE, rope_range = c(-40,40), rope_ci = 0.89,
                    cred.int.level = 0.89, hypothesis="equal", support=NULL)
 
 # lognormal sv
 ln_sv_ex <- conjugate(s1=rlnorm(100, log(130), log(1.3)), s2= rlnorm(100, log(100), log(1.6)),
  method = "lognormal",
                    priors = list( mu_log=c(log(10),log(10)),n=c(1,1),sigma_log=c(log(3),log(3)) ),
-                   plot=TRUE, rope_range = NULL, rope_ci = 0.89, rope_hdi = 0.95,
+                   plot=TRUE, rope_range = NULL, rope_ci = 0.89, 
                    cred.int.level = 0.89, hypothesis="equal", support=NULL)
 
 # Z test mv example
@@ -141,14 +140,14 @@ mv_gauss<-rbind(do.call(rbind, lapply(1:30, function(i){makeMvGauss(bins=180, mu
                 
 gauss_mv_ex <- conjugate(s1=mv_gauss[1:30,], s2= mv_gauss[31:60,], method = "gaussian",
                   priors = list( mu=c(0,0),n=c(1,1),s2=c(20,20) ),
-                  plot=TRUE, rope_range = c(-25, 25), rope_ci = 0.89, rope_hdi = 0.95,
+                  plot=TRUE, rope_range = c(-25, 25), rope_ci = 0.89,
                   cred.int.level = 0.89, hypothesis="equal", support=NULL)
                   
 # Z test sv example
 set.seed(123)
 gauss_sv_ex_bad <- conjugate(s1=rnorm(15, 50,10), s2= rnorm(15, 60,12), method = "gaussian",
                   priors = list( mu=c(0,0),n=c(1,1),s2=c(20,20) ),
-                  plot=TRUE, rope_range = c(-10, 10), rope_ci = 0.89, rope_hdi = 0.95,
+                  plot=TRUE, rope_range = c(-10, 10), rope_ci = 0.89, 
                   cred.int.level = 0.89, hypothesis="equal", support=NULL)
                   
 # Here the plot clearly shows we have a problem with the default support, so we specify one
@@ -157,7 +156,7 @@ gauss_sv_ex_bad <- conjugate(s1=rnorm(15, 50,10), s2= rnorm(15, 60,12), method =
 
 gauss_sv_ex <- conjugate(s1=rnorm(15, 50,10), s2= rnorm(15, 60,12), method = "gaussian",
                   priors = list( mu=c(0,0),n=c(1,1),s2=c(20,20) ),
-                  plot=TRUE, rope_range = c(-10, 10), rope_ci = 0.89, rope_hdi = 0.95,
+                  plot=TRUE, rope_range = c(-10, 10), rope_ci = 0.89, 
                   cred.int.level = 0.89, hypothesis="equal", support=seq(-20,120, 0.01))
 # Note that the ROPE probability is somewhat unstable here since the distribution of differences
 # is much wider than the ROPE interval.
@@ -174,7 +173,7 @@ mv_gauss<-rbind(do.call(rbind, lapply(1:30, function(i){makeMvGauss(bins=180, mu
 
 gaussianMeans_mv_ex <- conjugate(s1=mv_gauss[1:30,], s2= mv_gauss[31:60,], method="t",
                         priors = list( mu=c(0,0),n=c(1,1),s2=c(20,20) ),
-                        plot=TRUE, rope_range = c(-5,5), rope_ci = 0.89, rope_hdi = 0.95,
+                        plot=TRUE, rope_range = c(-5,5), rope_ci = 0.89, 
                         cred.int.level = 0.89, hypothesis="equal", support=NULL)
                         
                         
@@ -182,7 +181,7 @@ gaussianMeans_mv_ex <- conjugate(s1=mv_gauss[1:30,], s2= mv_gauss[31:60,], metho
 
 gaussianMeans_sv_ex <- conjugate(s1=rnorm(10, 50,10), s2= rnorm(10, 60,12), method="t",
                         priors = list( mu=c(0,0),n=c(1,1),s2=c(20,20) ),
-                        plot=TRUE, rope_range = c(-5,8), rope_ci = 0.89, rope_hdi = 0.95,
+                        plot=TRUE, rope_range = c(-5,8), rope_ci = 0.89, 
                         cred.int.level = 0.89, hypothesis="equal", support=NULL)
 
 
@@ -200,32 +199,54 @@ mv_beta<-rbind(do.call(rbind, lapply(1:30, function(i){makeMvBeta(n=100, a=5, b=
 
 beta_mv_ex <- conjugate(s1 = mv_beta[1:30,], s2= mv_beta[31:60,], method="beta",
               priors = list(a=c(0.5,0.5),b=c(0.5,0.5)),
-              plot=TRUE, rope_range = c(-0.1, 0.1), rope_ci = 0.89, rope_hdi = 0.95,
+              plot=TRUE, rope_range = c(-0.1, 0.1), rope_ci = 0.89, 
               cred.int.level = 0.89, hypothesis="equal")
 
 # beta sv example
 
 beta_sv_ex <- conjugate(s1 = rbeta(20, 5, 5), s2= rbeta(20, 8, 5), method="beta",
               priors = list(a=c(0.5,0.5),b=c(0.5,0.5)),
-              plot=TRUE, rope_range = c(-0.1, 0.1), rope_ci = 0.89, rope_hdi = 0.95,
+              plot=TRUE, rope_range = c(-0.1, 0.1), rope_ci = 0.89, 
               cred.int.level = 0.89, hypothesis="equal")
 
 # poisson sv example
 
 poisson_sv_ex <- conjugate(s1 = rpois(20, 10), s2= rpois(20, 8), method="poisson",
               priors = list(a=c(0.5,0.5),b=c(0.5,0.5)),
-              plot=TRUE, rope_range = c(-1, 1), rope_ci = 0.89, rope_hdi = 0.95,
+              plot=TRUE, rope_range = c(-1, 1), rope_ci = 0.89, 
               cred.int.level = 0.89, hypothesis="equal")
 
 # negative binomial sv example
 # knowing r (required number of successes) is an important caveat for this method.
 # in the current implementation we suggest using the poisson method for data such as leaf counts
 
-negbin_sv_ex <- conjugate(s1 = rnbinom(20, 10, 0.5), s2= rnbinom(20, 10, 0.25), method="poisson",
+negbin_sv_ex <- conjugate(s1 = rnbinom(20, 10, 0.5), s2= rnbinom(20, 10, 0.25), method="negbin",
               priors = list(r = c(10, 10), a=c(0.5,0.5),b=c(0.5,0.5)),
-              plot=TRUE, rope_range = c(-1, 1), rope_ci = 0.89, rope_hdi = 0.95,
+              plot=TRUE, rope_range = c(-1, 1), rope_ci = 0.89, 
               cred.int.level = 0.89, hypothesis="equal")
-              
+
+# Dirichlet mv example
+
+makeMvLn<-function(bins=500,mu_log,sigma_log){
+setNames(data.frame(matrix(hist(rlnorm(2000,mu_log, sigma_log),
+                                breaks=seq(1,bins,5), plot=FALSE)$counts, nrow=1)),
+                                         paste0("b",seq(1,bins,5))[-1] ) }
+set.seed(123) 
+mv_ln<-rbind(do.call(rbind,
+                      lapply(1:30, function(i){makeMvLn(mu_log=log(130),
+                                          sigma_log=log(1.3) )})),
+            do.call(rbind, lapply(1:30, function(i){makeMvLn(mu_log=log(100),
+                                          sigma_log=log(1.2) )})))
+s1 <- mv_ln[1:30, ]
+s2 <- mv_ln[31:60, ]
+diri_ex_1 <- conjugate(s1, s2, method = "dirichlet", priors=NULL, plot=TRUE,
+      rope_range = c(-0.025, 0.025), rope_ci = 0.89, 
+      cred.int.level = 0.89, hypothesis="equal")
+      
+      
+      
+
+
 # Example usage with plantCV data
 ## Not run:
 library(data.table)
@@ -253,11 +274,11 @@ B73_sample <- wide[wide$genotype=="B73" &
 
 hue_res_t <- conjugate(s1 = mo17_sample, s2= B73_sample, method="t",
               priors = list( mu=c(0,0),n=c(1,1),s2=c(20,20) ),
-              plot=TRUE, rope_range = c(-10,10), rope_ci = 0.89, rope_hdi = 0.95,
+              plot=TRUE, rope_range = c(-10,10), rope_ci = 0.89, 
               cred.int.level = 0.89, hypothesis="equal")
               
 hue_res_ln <- conjugate(s1 = mo17_sample, s2= B73_sample, method="lognormal",
-              plot=TRUE, rope_range = c(-10,10), rope_ci = 0.89, rope_hdi = 0.95,
+              plot=TRUE, rope_range = c(-10,10), rope_ci = 0.89, 
               cred.int.level = 0.89, hypothesis="equal")
 # Picking the right distribution makes a difference,
 # checking plots of your data (see ?pcv.joyplot for mv traits)
@@ -271,7 +292,7 @@ B73_area <- wide[wide$genotype=="B73" & wide$DAS > 18 & wide$fertilizer == 50, "
 
 area_res_t <- conjugate(s1 = mo17_area, s2= B73_area, method="t",
               priors = list( mu=c(0,0),n=c(1,1),s2=c(20,20) ),
-              plot=TRUE, rope_range = c(-5,5), rope_ci = 0.89, rope_hdi = 0.95,
+              plot=TRUE, rope_range = c(-5,5), rope_ci = 0.89, 
               cred.int.level = 0.89, hypothesis="equal")
 
 ## End(Not run)


### PR DESCRIPTION
Adding options for conjugate to use a dirichlet distribution to compare image histograms. The goal here is to be able to compare image histograms that do not follow a typical unimodal distribution (beta/gaussian/lognormal/etc that are already supported). These edits would add two versions of the dirichlet distribution, one that does not use proper HDIs and ROPE testing and treats the histograms as observed alpha vectors and another that does use HDIs and ROPE testing after reparameterizing alpha to mean * precision.