### PR TITLE
change to pcv.net for labeling nodes

### DIFF
--- a/R/net.R
+++ b/R/net.R
@@ -105,8 +105,8 @@ pcv.net <- function(emd = NULL, meta = NULL, dissim = TRUE, distCol = "emd", fil
     j <- m[[2]]
     f <- eg[[i]][match(gg$index, eg$from)]
     to <- eg[[j]][match(gg$index, eg$to)]
-    f[which(is.na(f))] <- to[which(is.na(f))]
-    f
+    to[which(is.na(to))] <- f[which(is.na(to))]
+    to
   }) # this can be NA if there is no 'from' edge connected to a node, so check 'to' edges as well.
   colnames(gg)[newCols] <- meta
   gg[, newCols] <- type.convert(gg[, newCols], as.is = TRUE)


### PR DESCRIPTION
noticed an error in the network example where the trimodal labels were not appearing as trimodal but as normal. I think this is a carryover from the smarter emd calculation. Fix I'm using here is to use the "to" labels instead of the "from" labels for matching groups and nodes. Works in the vignette example.